### PR TITLE
Bump google_mlkit_face_detection

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: face_collect_native
 description: "A face collection liveness package based on Google ML"
-version: 1.0.3
+version: 1.0.4
 homepage: https://github.com/LiangLuDev/face_collect_native.git
 
 environment:
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  google_mlkit_face_detection: ^0.11.0
+  google_mlkit_face_detection: ^0.12.0
   camera: ^0.11.0+2
   image: ^4.0.17
   lottie: ^1.0.1


### PR DESCRIPTION
Required for compatibility with `mobile_scanner: ^6.0.0`.